### PR TITLE
Use shorter user agent string

### DIFF
--- a/lib/sepa/application_request.rb
+++ b/lib/sepa/application_request.rb
@@ -177,7 +177,7 @@ module Sepa
         set_node('Environment', @environment.to_s.upcase)
         set_node("CustomerId", @customer_id)
         set_node("Timestamp", iso_time)
-        set_node("SoftwareId", "Sepa Transfer Library version #{VERSION}")
+        set_node("SoftwareId", "Sepa Transfer Library #{VERSION}")
         set_node("Command", pretty_command) unless @command == :renew_certificate
       end
 

--- a/lib/sepa/soap_builder.rb
+++ b/lib/sepa/soap_builder.rb
@@ -211,7 +211,7 @@ module Sepa
         set_node @template, 'bxd|RequestId',          request_id
         set_node @template, 'bxd|Timestamp',          iso_time
         set_node @template, 'bxd|Language',           @language
-        set_node @template, 'bxd|UserAgent',          "Sepa Transfer Library version #{VERSION}"
+        set_node @template, 'bxd|UserAgent',          "Sepa Transfer Library #{VERSION}"
       end
 
       def set_application_request

--- a/test/sepa/banks/danske/danske_generic_soap_builder_test.rb
+++ b/test/sepa/banks/danske/danske_generic_soap_builder_test.rb
@@ -91,7 +91,7 @@ class DanskeGenericSoapBuilderTest < ActiveSupport::TestCase
   def test_user_agent_is_set_correctly
     user_agent_node = @doc.at("//bxd:UserAgent", 'bxd' => 'http://model.bxd.fi')
 
-    assert_equal user_agent_node.content, "Sepa Transfer Library version " + Sepa::VERSION
+    assert_equal user_agent_node.content, "Sepa Transfer Library " + Sepa::VERSION
   end
 
   def test_receiver_is_is_set_correctly

--- a/test/sepa/banks/nordea/nordea_application_request_test.rb
+++ b/test/sepa/banks/nordea/nordea_application_request_test.rb
@@ -94,7 +94,7 @@ class NordeaApplicationRequestTest < ActiveSupport::TestCase
   end
 
   def test_should_have_software_id_set_with_all_commands
-    string = "Sepa Transfer Library version #{Sepa::VERSION}"
+    string = "Sepa Transfer Library #{Sepa::VERSION}"
 
     assert_equal @doc_file.at_css("SoftwareId").content, string
     assert_equal @doc_get.at_css("SoftwareId").content, string

--- a/test/sepa/banks/nordea/nordea_cert_application_request_test.rb
+++ b/test/sepa/banks/nordea/nordea_cert_application_request_test.rb
@@ -47,7 +47,7 @@ class NordeaCertApplicationRequestTest < ActiveSupport::TestCase
   end
 
   test 'should have software id set' do
-    assert_equal @xml.at_css("SoftwareId").content, "Sepa Transfer Library version #{Sepa::VERSION}"
+    assert_equal @xml.at_css("SoftwareId").content, "Sepa Transfer Library #{Sepa::VERSION}"
   end
 
   test 'should have service set' do

--- a/test/sepa/banks/nordea/nordea_generic_soap_builder_test.rb
+++ b/test/sepa/banks/nordea/nordea_generic_soap_builder_test.rb
@@ -105,7 +105,7 @@ class NordeaGenericSoapBuilderTest < ActiveSupport::TestCase
       "//bxd:UserAgent", 'bxd' => 'http://model.bxd.fi'
     ).first
 
-    assert_equal user_agent_node.content, "Sepa Transfer Library version " + Sepa::VERSION
+    assert_equal user_agent_node.content, "Sepa Transfer Library " + Sepa::VERSION
   end
 
   def test_receiver_is_is_set_correctly

--- a/test/sepa/banks/nordea/nordea_renew_cert_application_request_test.rb
+++ b/test/sepa/banks/nordea/nordea_renew_cert_application_request_test.rb
@@ -31,7 +31,7 @@ class NordeaRenewCertApplicationRequestTest < ActiveSupport::TestCase
   end
 
   test "software id is set correctly" do
-    assert_equal "Sepa Transfer Library version #{Sepa::VERSION}", @doc.at_css("SoftwareId").content
+    assert_equal "Sepa Transfer Library #{Sepa::VERSION}", @doc.at_css("SoftwareId").content
   end
 
   test "service is set correctly" do

--- a/test/sepa/banks/op/op_cert_application_request_test.rb
+++ b/test/sepa/banks/op/op_cert_application_request_test.rb
@@ -43,7 +43,7 @@ class OpCertApplicationRequestTest < ActiveSupport::TestCase
   end
 
   test "software id is set correctly" do
-    assert_equal @xml.at_css("SoftwareId").content, "Sepa Transfer Library version #{Sepa::VERSION}"
+    assert_equal @xml.at_css("SoftwareId").content, "Sepa Transfer Library #{Sepa::VERSION}"
   end
 
   test "service is set correctly" do


### PR DESCRIPTION
Use shorter user agent string because OP supports a maximum of 35 characters